### PR TITLE
feat: 메인 페이지 Album API 연결, 클릭 시 반응, 디자인 수정

### DIFF
--- a/components/Album/index.tsx
+++ b/components/Album/index.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import React from "react";
 import { TopSong } from "../../shared/type";
+import useStore from "../../store";
 import AlbumContent from "../AlbumContent";
 import { Wrapper, ImageWrapper } from "./styles";
 
@@ -10,11 +11,15 @@ interface IProps {
 }
 
 const Album = ({ album, rank }: IProps) => {
+  const currentRank = useStore((state) => state.currentRank);
+
   return (
     <Wrapper>
-      <ImageWrapper>
-        <Image src={album.images[0].url} width={120} height={120} />
-      </ImageWrapper>
+      {currentRank !== rank && (
+        <ImageWrapper>
+          <Image src={album.images[0].url} width={150} height={150} />
+        </ImageWrapper>
+      )}
       <AlbumContent album={album} rank={rank} />
     </Wrapper>
   );

--- a/components/Album/styles.ts
+++ b/components/Album/styles.ts
@@ -3,11 +3,11 @@ import styled from "styled-components";
 export const Wrapper = styled.div`
   display: flex;
   align-items: center;
+  width: 1000px;
 `;
 
 export const ImageWrapper = styled.div`
   padding: 0px 30px;
-  border-left: 1px solid black;
   border-right: 1px solid black;
   padding-bottom: 13px;
 `;

--- a/components/AlbumContent/index.tsx
+++ b/components/AlbumContent/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { TopSong } from "../../shared/type";
+import useStore from "../../store";
 import AlbumMenu from "../AlbumMenu";
 import { Artist, Description, Name, Rank, Wrapper } from "./styles";
 
@@ -9,14 +10,17 @@ interface IProps {
 }
 
 const AlbumContent = ({ album, rank }: IProps) => {
+  const currentRank = useStore((state) => state.currentRank);
+  const isClicked = currentRank === rank;
+
   return (
-    <Wrapper>
+    <Wrapper isClicked={isClicked}>
       <Rank>{rank}</Rank>
       <Description>
         <Name>{album.name}</Name>
         <Artist>{album.artists[0].name}</Artist>
       </Description>
-      <AlbumMenu album={album} rank={rank} />
+      {currentRank !== rank && <AlbumMenu album={album} rank={rank} />}
     </Wrapper>
   );
 };

--- a/components/AlbumContent/index.tsx
+++ b/components/AlbumContent/index.tsx
@@ -16,7 +16,7 @@ const AlbumContent = ({ album, rank }: IProps) => {
         <Name>{album.name}</Name>
         <Artist>{album.artists[0].name}</Artist>
       </Description>
-      <AlbumMenu album={album} />
+      <AlbumMenu album={album} rank={rank} />
     </Wrapper>
   );
 };

--- a/components/AlbumContent/index.tsx
+++ b/components/AlbumContent/index.tsx
@@ -16,7 +16,7 @@ const AlbumContent = ({ album, rank }: IProps) => {
         <Name>{album.name}</Name>
         <Artist>{album.artists[0].name}</Artist>
       </Description>
-      <AlbumMenu />
+      <AlbumMenu album={album} />
     </Wrapper>
   );
 };

--- a/components/AlbumContent/styles.ts
+++ b/components/AlbumContent/styles.ts
@@ -1,9 +1,10 @@
 import styled from "styled-components";
 
-export const Wrapper = styled.div`
+export const Wrapper = styled.div<{ isClicked: boolean }>`
   display: flex;
   border-bottom: 1px solid black;
   margin-left: 37px;
+  width: ${(props) => (props.isClicked ? "1000px" : "")};
 `;
 
 export const Rank = styled.p`

--- a/components/AlbumMenu/index.tsx
+++ b/components/AlbumMenu/index.tsx
@@ -1,17 +1,28 @@
 import React from "react";
 import { getCertainAlbum } from "../../lib/spotify";
 import { TopSong } from "../../shared/type";
+import useStore from "../../store";
 import Button from "../Button";
 import { Wrapper } from "./styles";
 
 interface IProps {
   album: TopSong;
+  rank: number;
 }
 
-const AlbumMenu = ({ album }: IProps) => {
+const AlbumMenu = ({ album, rank }: IProps) => {
+  const toggleCurrentRank = useStore((state) => state.toggleCurrentRank);
+  const toggleCurrentTrack = useStore((state) => state.toggleCurrentTrack);
+
+  const onClickTracks = async () => {
+    const tracks = await getCertainAlbum(album.id);
+    toggleCurrentRank(rank);
+    toggleCurrentTrack(tracks);
+  };
+
   return (
     <Wrapper>
-      <Button>
+      <Button onClick={onClickTracks}>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           className="h-6 w-6"
@@ -27,7 +38,7 @@ const AlbumMenu = ({ album }: IProps) => {
           />
         </svg>
       </Button>
-      <Button onClick={() => getCertainAlbum(album.id)}>
+      <Button>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           className="h-6 w-6"

--- a/components/AlbumMenu/index.tsx
+++ b/components/AlbumMenu/index.tsx
@@ -12,11 +12,15 @@ interface IProps {
 
 const AlbumMenu = ({ album, rank }: IProps) => {
   const toggleCurrentRank = useStore((state) => state.toggleCurrentRank);
+  const toggleCurrentAlbumImage = useStore(
+    (state) => state.toggleCurrentAlbumImage
+  );
   const toggleCurrentTrack = useStore((state) => state.toggleCurrentTrack);
 
   const onClickTracks = async () => {
     const tracks = await getCertainAlbum(album.id);
     toggleCurrentRank(rank);
+    toggleCurrentAlbumImage(album.images[0].url);
     toggleCurrentTrack(tracks);
   };
 

--- a/components/AlbumMenu/index.tsx
+++ b/components/AlbumMenu/index.tsx
@@ -1,8 +1,14 @@
 import React from "react";
+import { getCertainAlbum } from "../../lib/spotify";
+import { TopSong } from "../../shared/type";
 import Button from "../Button";
 import { Wrapper } from "./styles";
 
-const AlbumMenu = () => {
+interface IProps {
+  album: TopSong;
+}
+
+const AlbumMenu = ({ album }: IProps) => {
   return (
     <Wrapper>
       <Button>
@@ -21,7 +27,7 @@ const AlbumMenu = () => {
           />
         </svg>
       </Button>
-      <Button>
+      <Button onClick={() => getCertainAlbum(album.id)}>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           className="h-6 w-6"

--- a/components/Button/index.tsx
+++ b/components/Button/index.tsx
@@ -3,10 +3,11 @@ import { Wrapper } from "./styles";
 
 interface IProps {
   children: React.ReactNode;
+  onClick?: () => void;
 }
 
-const Button = ({ children }: IProps) => {
-  return <Wrapper>{children}</Wrapper>;
+const Button = ({ children, onClick }: IProps) => {
+  return <Wrapper onClick={onClick}>{children}</Wrapper>;
 };
 
 export default Button;

--- a/components/Chart/index.tsx
+++ b/components/Chart/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useQuery } from "react-query";
 import { getTopAlbums } from "../../lib/spotify";
+import useStore from "../../store";
 import Album from "../Album";
 import { Wrapper } from "./styles";
 
@@ -8,11 +9,21 @@ const Chart = () => {
   const { data: topAlbums } = useQuery("topAlbums", getTopAlbums, {
     suspense: true,
   });
+  const currentRank = useStore((state) => state.currentRank);
+  const currentTrack = useStore((state) => state.currentTrack);
+
+  console.log("CurrentRank", currentRank);
+  console.log("CurrentTrack", currentTrack);
 
   return (
     <Wrapper>
       {topAlbums?.map((album, index) => (
-        <Album key={index} album={album} rank={index + 1} />
+        <div>
+          <Album key={index} album={album} rank={index + 1} />
+          {currentRank === index + 1 && currentTrack?.length && (
+            <div>Clicked Track</div>
+          )}
+        </div>
       ))}
     </Wrapper>
   );

--- a/components/Chart/index.tsx
+++ b/components/Chart/index.tsx
@@ -1,27 +1,34 @@
+import Image from "next/image";
 import React from "react";
 import { useQuery } from "react-query";
 import { getTopAlbums } from "../../lib/spotify";
 import useStore from "../../store";
 import Album from "../Album";
-import { Wrapper } from "./styles";
+import Track from "../Track";
+import { Wrapper, SelectedAlbumWrapper, TracksWrapper } from "./styles";
 
 const Chart = () => {
   const { data: topAlbums } = useQuery("topAlbums", getTopAlbums, {
     suspense: true,
   });
   const currentRank = useStore((state) => state.currentRank);
+  const currentAlbumImage = useStore((state) => state.currentAlbumImage);
   const currentTrack = useStore((state) => state.currentTrack);
-
-  console.log("CurrentRank", currentRank);
-  console.log("CurrentTrack", currentTrack);
 
   return (
     <Wrapper>
       {topAlbums?.map((album, index) => (
-        <div>
-          <Album key={index} album={album} rank={index + 1} />
+        <div key={album.id}>
+          <Album album={album} rank={index + 1} />
           {currentRank === index + 1 && currentTrack?.length && (
-            <div>Clicked Track</div>
+            <SelectedAlbumWrapper>
+              <Image src={currentAlbumImage} width={450} height={450} />
+              <TracksWrapper>
+                {currentTrack.map((track, index) => (
+                  <Track key={track.id} number={index + 1} track={track} />
+                ))}
+              </TracksWrapper>
+            </SelectedAlbumWrapper>
           )}
         </div>
       ))}

--- a/components/Chart/styles.ts
+++ b/components/Chart/styles.ts
@@ -5,3 +5,20 @@ export const Wrapper = styled.div`
   flex-direction: column;
   cursor: pointer;
 `;
+
+export const SelectedAlbumWrapper = styled.div`
+  display: flex;
+  padding: 40px;
+`;
+
+export const TracksWrapper = styled.div`
+  width: 900px;
+  max-height: 530px;
+  padding: 40px;
+  overflow-y: scroll;
+  margin: 10px 0px;
+  border-radius: 10px;
+  ::-webkit-scrollbar {
+    display: none;
+  }
+`;

--- a/components/SideMenu/styles.ts
+++ b/components/SideMenu/styles.ts
@@ -3,6 +3,7 @@ import styled from "styled-components";
 export const Wrapper = styled.div`
   width: 170px;
   border-left: 1px solid black;
+  border-right: 1px solid black;
   padding-left: 20px;
   padding-right: 60px;
 `;

--- a/components/Track/index.tsx
+++ b/components/Track/index.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import styled from "styled-components";
+import { Track } from "../../shared/type";
+import Button from "../Button";
+import { TrackInfo, Wrapper } from "./styles";
+
+interface IProps {
+  number: number;
+  track: Track;
+}
+
+const Track = ({ number, track }: IProps) => {
+  return (
+    <Wrapper>
+      <TrackInfo>
+        Track {number} {track.name}
+      </TrackInfo>
+      <div>
+        <Button>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-6 w-6"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M5 12h.01M12 12h.01M19 12h.01M6 12a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0z"
+            />
+          </svg>
+        </Button>
+        <Button>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-6 w-6"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
+            />
+          </svg>
+        </Button>
+      </div>
+    </Wrapper>
+  );
+};
+
+export default Track;

--- a/components/Track/styles.ts
+++ b/components/Track/styles.ts
@@ -1,0 +1,16 @@
+import styled from "styled-components";
+
+export const Wrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: 20px 0px;
+  border-bottom: 1px solid black;
+  width: 100%;
+  margin-left: 20px;
+`;
+
+export const TrackInfo = styled.p`
+  font-size: 22px;
+  font-weight: 700;
+  width: 500px;
+`;

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -27,8 +27,6 @@ export const getCertainAlbum = async (id: string): Promise<Track[] | null> => {
       },
     });
 
-    console.log(response.data.items);
-
     return response.data.items;
   } catch (e) {
     return null;

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { TopSong } from "../shared/type";
+import { TopSong, Track } from "../shared/type";
 
 const BASE_URL = "https://api.spotify.com/v1";
 
@@ -13,6 +13,23 @@ export const getTopAlbums = async (): Promise<TopSong[] | null> => {
     });
 
     return response.data.albums.items;
+  } catch (e) {
+    return null;
+  }
+};
+
+export const getCertainAlbum = async (id: string): Promise<Track[] | null> => {
+  try {
+    const response = await axios(`${BASE_URL}/albums/${id}/tracks`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${process.env.NEXT_PUBLIC_ACCESS_TOKEN}`,
+      },
+    });
+
+    console.log(response.data.items);
+
+    return response.data.items;
   } catch (e) {
     return null;
   }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "react-dom": "18.0.0",
     "react-query": "^3.34.20",
     "styled-components": "^5.3.5",
-    "styled-reset": "^4.3.4"
+    "styled-reset": "^4.3.4",
+    "zustand": "^3.7.2"
   },
   "devDependencies": {
     "@types/node": "17.0.24",

--- a/shared/type.ts
+++ b/shared/type.ts
@@ -10,4 +10,10 @@ export interface TopSong {
   artists: Artist[];
   name: string;
   images: AlbumImage[];
+  id: string;
+}
+
+export interface Track {
+  name: string;
+  id: string;
 }

--- a/store/index.ts
+++ b/store/index.ts
@@ -4,6 +4,8 @@ import { Track } from "../shared/type";
 interface CurrentTrackState {
   currentRank: number;
   toggleCurrentRank: (rank: number) => void;
+  currentAlbumImage: string;
+  toggleCurrentAlbumImage: (imgUrl: string) => void;
   currentTrack: Track[] | null;
   toggleCurrentTrack: (tracks: Track[] | null) => void;
 }
@@ -11,6 +13,9 @@ interface CurrentTrackState {
 const useStore = create<CurrentTrackState>((set) => ({
   currentRank: 0,
   toggleCurrentRank: (rank: number) => set({ currentRank: rank }),
+  currentAlbumImage: "",
+  toggleCurrentAlbumImage: (imgUrl: string) =>
+    set({ currentAlbumImage: imgUrl }),
   currentTrack: null,
   toggleCurrentTrack: (tracks: Track[] | null) => set({ currentTrack: tracks }),
 }));

--- a/store/index.ts
+++ b/store/index.ts
@@ -1,0 +1,18 @@
+import create from "zustand";
+import { Track } from "../shared/type";
+
+interface CurrentTrackState {
+  currentRank: number;
+  toggleCurrentRank: (rank: number) => void;
+  currentTrack: Track[] | null;
+  toggleCurrentTrack: (tracks: Track[] | null) => void;
+}
+
+const useStore = create<CurrentTrackState>((set) => ({
+  currentRank: 0,
+  toggleCurrentRank: (rank: number) => set({ currentRank: rank }),
+  currentTrack: null,
+  toggleCurrentTrack: (tracks: Track[] | null) => set({ currentTrack: tracks }),
+}));
+
+export default useStore;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2062,3 +2062,8 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+zustand@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-3.7.2.tgz#7b44c4f4a5bfd7a8296a3957b13e1c346f42514d"
+  integrity sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==


### PR DESCRIPTION
### Related to Any Issues?
- 메인페이지 특정 Album의 Tracks 연결

### What Changed?
- Album + 버튼 클릭시 해당 Tracks 펼쳐서 보여주기
- 디자인 추가

### Any Screenshot
<img width="1440" alt="스크린샷 2022-04-18 오후 2 41 05 2" src="https://user-images.githubusercontent.com/72953316/163761101-3f835189-9a42-4cea-bef4-8efc75e7f199.png">